### PR TITLE
Adds @typescript-eslint/no-unused-vars rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,8 @@ module.exports = {
   ],
   root: true,
   rules: {
+    "@typescript-eslint/consistent-type-definitions": ["error", "type"],
+    "@typescript-eslint/no-unused-vars": ["error", { ignoreRestSiblings: true }],
     curly: "error",
     "import/no-cycle": "error",
     "import/no-default-export": "error",
@@ -53,7 +55,6 @@ module.exports = {
     "sort-destructure-keys/sort-destructure-keys": ["warn", { caseSensitive: false }],
     "sort-keys-fix/sort-keys-fix": ["warn", "asc", { caseSensitive: false }],
     "unicorn/switch-case-braces": "error",
-    "@typescript-eslint/consistent-type-definitions": ["error", "type"],
   },
   settings: {
     "import/resolver": {

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports = {
   root: true,
   rules: {
     "@typescript-eslint/consistent-type-definitions": ["error", "type"],
-    "@typescript-eslint/no-unused-vars": ["error", { ignoreRestSiblings: true }],
+    "@typescript-eslint/no-unused-vars": ["error", { varsIgnorePattern: "_", argsIgnorePattern: "_" }],
     curly: "error",
     "import/no-cycle": "error",
     "import/no-default-export": "error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iden3/eslint-config-react-ts",
-  "version": "1.4.0",
+  "version": "1.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@iden3/eslint-config-react-ts",
-      "version": "1.4.0",
+      "version": "1.6.0",
       "license": "gpl-3.0",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^5.59.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iden3/eslint-config-react-ts",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Strict & opinionated ESLint config for React/Typescript projects.",
   "main": "index.js",
   "author": "@iden3",


### PR DESCRIPTION
This PR adds the `@typescript-eslint/no-unused-vars` rule with the `varsIgnorePattern` and `argsIgnorePattern` options set to `true` to improve object destructuring.